### PR TITLE
Token via Osscar the OSS cat (our very own GitHub app).

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -15,10 +15,16 @@ permissions:
   contents: read
   pages: write
   id-token: write
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
 jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         id: generate_token


### PR DESCRIPTION
Better rate limit than a personal token. (🎉)

Potentially more secure, as the GRAPHQL_TOKEN expires after one hour (we do have to upload the private key of the app as a repo secret though, so ¯\\\_(ツ)_/¯ )