### PR TITLE
Bump the tar version.

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -765,10 +765,11 @@
       }
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/tar": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
-      "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
-      "license": "ISC",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",


### PR DESCRIPTION
I've no idea why @dependabot can't do this itself in from the security warnings tab.
Nor why `npm audit fix` doesn't fix this (does that maybe mean that the `backend/` and `app/` lockfiles are not needed/used??)

But this updates `tar` to a vulnerability-fixed version. A human needed to do this. 😞 