### PR TITLE
Type error fix.

### DIFF
--- a/app/src/components/RepositoriesTable.tsx
+++ b/app/src/components/RepositoriesTable.tsx
@@ -161,7 +161,7 @@ const HeaderCellRenderer = <R = unknown,>({
             // The click handler here is used to stop the header from being sorted
             <Box
               className="shadow-xl min-w-64 p-4 rounded"
-              onClick={(e) => e.stopPropagation()}
+              onClick={(e: { stopPropagation: () => any; }) => e.stopPropagation()}
               sx={{
                 backgroundColor: 'Background',
                 border: '1px solid',

--- a/app/src/components/TopicCell.tsx
+++ b/app/src/components/TopicCell.tsx
@@ -19,7 +19,7 @@ const TopicCell = ({
         return (
           <Box
             className="shadow-xl min-w-64 p-4 rounded space-x-2"
-            onClick={(e) => e.stopPropagation()}
+            onClick={(e: { stopPropagation: () => any }) => e.stopPropagation()}
             sx={{
               backgroundColor: 'Background',
               border: '1px solid',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       ],
       "devDependencies": {
         "@dotenvx/dotenvx": "^1.51.0",
+        "@types/styled-components": "^5.1.36",
         "concurrently": "^9.2.1",
         "prettier": "^3.6.2",
         "yaml": "^2.6.1"
@@ -4263,6 +4264,19 @@
         "@types/unist": "^2"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/js-cookie": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
@@ -4362,6 +4376,19 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
+    },
+    "node_modules/@types/styled-components": {
+      "version": "5.1.36",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.36.tgz",
+      "integrity": "sha512-pGMRNY5G2rNDKEv2DOiFYa7Ft1r0jrhmgBwHhOMzPTgCjO76bCot0/4uEfqj7K0Jf1KdQmDtAuaDk9EAs9foSw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hoist-non-react-statics": "*",
+        "@types/react": "*",
+        "csstype": "^3.2.2"
+      }
     },
     "node_modules/@types/styled-system": {
       "version": "5.1.22",
@@ -6873,9 +6900,10 @@
       "license": "CC0-1.0"
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.51.0",
+    "@types/styled-components": "^5.1.36",
     "concurrently": "^9.2.1",
     "prettier": "^3.6.2",
     "yaml": "^2.6.1"


### PR DESCRIPTION
Fixes the [untyped error](https://github.com/UCL/open-source-dashboard/pull/87#issuecomment-3641057084), and unblocks

- #87 

Now, why does a patch version of next cause a wild untyped error to appear? I've no idea.

- Adds type to two places in this codebase.
- Adds typing for the [styled-components library](https://stackoverflow.com/a/69892814/1444054).